### PR TITLE
Set static IP for PIP

### DIFF
--- a/scenarios/deeplearning/code/bicep/deploy.vm.bicep
+++ b/scenarios/deeplearning/code/bicep/deploy.vm.bicep
@@ -133,7 +133,7 @@ resource pip 'Microsoft.Network/publicIPAddresses@2022-01-01' = {
     name: 'Standard'
   }
   properties: {
-    publicIPAllocationMethod: 'Dynamic'
+    publicIPAllocationMethod: 'Static'
     dnsSettings: {
       domainNameLabel: prefix
     }


### PR DESCRIPTION
I had error during deployment below details
"At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/DeployOperations for usage details.\",\r\n        \"details\": [\r\n          {\r\n            \"code\": \"BadRequest\",\r\n            \"message\": \"{\\r\\n  \\\"error\\\": {\\r\\n    \\\"code\\\": \\\"StandardSkuPublicIPAddressesMustBeStatic\\\",\\r\\n    \\\"message\\\": \\\"Standard sku publicIp /subscriptions/7798bfea-7477-48a8-ab1a-8eef391c0218/resourceGroups/deepl-rg/providers/Microsoft.Network/publicIPAddresses/deepl-ip must have AllocationMethod set to Static.